### PR TITLE
adds a docker-compose build with an nginx reverse proxy 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rust
+RUN cargo install cargo-edit
+COPY src /opt/distrust/src
+COPY Cargo.toml /opt/distrust/Cargo.toml
+WORKDIR /opt/distrust
+RUN cargo build
+CMD ["cargo", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  distrust:
+    build: .
+    networks:
+      - web_distrust_nw
+  nginx:
+    image: "nginx:mainline-alpine"
+    ports:
+      - "8086:8086"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d
+    networks:
+      - web_distrust_nw
+    depends_on: 
+      - distrust
+networks:
+  web_distrust_nw:
+    driver: bridge

--- a/nginx/conf.d/distrustapp.conf
+++ b/nginx/conf.d/distrustapp.conf
@@ -1,0 +1,14 @@
+server {
+    listen 8086;
+    server_name localhost;
+
+    location / {
+        proxy_set_header   Host                 $host;
+        proxy_set_header   X-Real-IP            $remote_addr;
+        proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto    $scheme;
+        proxy_set_header Host $http_host;
+	client_max_body_size 100M;
+        proxy_pass http://distrust:8086;
+    }
+}


### PR DESCRIPTION
This is a docker image that builds the distrust app, then runs it behind an nginx reverse proxy.

The intent was to easily simulate multiple copies of distrust on their own toy network without having to standup a full k8 system.